### PR TITLE
warn via logging if the config file cannot be written

### DIFF
--- a/src/Stingray.py
+++ b/src/Stingray.py
@@ -1,5 +1,6 @@
 import collections
 import idautils
+import logging
 import idaapi
 import idc
 import os
@@ -81,7 +82,10 @@ class Config( object ):
         if Config.MENU_CONTEXT:
             idaapi.del_menu_item(Config.MENU_CONTEXT)
         
-        Config.save()
+        try:
+            Config.save()
+        except IOError:
+            logging.getLogger("Stingray").warning("Failed to write config file")
 
 
     @staticmethod


### PR DESCRIPTION
on my analysis system, IDA does have permission to write to the default config file. so, this patch simply warns the user (who probably doesnt actually have the reaction time to catch the message in the script output pane) that the config file wasn't written.
