### PR TITLE
Fix namespace pollution error "AttributeError class Config has no attribute 'destory'" because the plugin IDAtropy has the same class name Config

### DIFF
--- a/src/Stingray.py
+++ b/src/Stingray.py
@@ -5,6 +5,7 @@ import idaapi
 import idc
 import os
 
+from . import Config
 class Config( idaapi.action_handler_t ):
 
     PLUGIN_NAME         = "Stingray"


### PR DESCRIPTION
Fix namespace pollution error "AttributeError class Config has no attribute 'destory'" because the plugin IDAtropy has the same class name Config.

After using IDAtropy and close the idb, this error message appears:
![image](https://user-images.githubusercontent.com/526959/57905456-d549e100-78a0-11e9-9aa2-b8defed4041a.png)

A similar error: https://github.com/igogo-x86/HexRaysPyTools/issues/19
