### PR TITLE
Update plugin to be compatible with IDA 7.2

### DIFF
--- a/src/Stingray.py
+++ b/src/Stingray.py
@@ -8,6 +8,7 @@ import os
 
 
 if idaapi.IDA_SDK_VERSION > 700:
+   # based on based on https://www.hex-rays.com/products/ida/support/ida74_idapython_no_bc695_porting_guide.shtml
     get_flags = ida_bytes.get_full_flags
 else:
     get_flags = idc.GetFlags
@@ -357,4 +358,3 @@ if Config.PLUGIN_TEST:
     p.init()
     p.run()
     p.term()
-


### PR DESCRIPTION
closes #7 
I believe that this should fix the issue reported.
I have tested this on IDA 7.2 only.
(I think this should also be compatible with IDA 7.3 & 7.4 however this is untested, I am just basing this off [this](https://www.hex-rays.com/products/ida/support/ida74_idapython_no_bc695_porting_guide.shtml).
This should hopefully be backward compatible with previous versions also.